### PR TITLE
fix: Windows build errors for cross-platform compilation

### DIFF
--- a/internal/lock/process_check.go
+++ b/internal/lock/process_check.go
@@ -1,63 +1,13 @@
 package lock
 
 import (
-	"errors"
 	"os"
-	"runtime"
-	"strconv"
-	"syscall"
 )
 
 // processExists checks if a process with the given PID exists
-// Cross-platform implementation
+// The actual implementation is platform-specific
 func processExists(pid int) bool {
-	switch runtime.GOOS {
-	case "windows":
-		return processExistsWindows(pid)
-	default:
-		return processExistsUnix(pid)
-	}
-}
-
-// processExistsUnix checks if a process exists on Unix-like systems
-func processExistsUnix(pid int) bool {
-	// Try to send signal 0 to the process
-	// If the process exists, we get nil or permission error
-	// If the process doesn't exist, we get ESRCH
-	err := syscall.Kill(pid, 0)
-
-	if err == nil {
-		return true // Process exists and we can signal it
-	}
-
-	// Check the specific error
-	var errno syscall.Errno
-	if errors.As(err, &errno) {
-		switch errno { //nolint:exhaustive // We only care about specific errno values
-		case syscall.ESRCH:
-			return false // Process doesn't exist
-		case syscall.EPERM:
-			return true // Process exists but we don't have permission
-		default:
-			return false // Other error, assume process doesn't exist
-		}
-	}
-
-	return false
-}
-
-// processExistsWindows checks if a process exists on Windows
-func processExistsWindows(pid int) bool {
-	// On Windows, we check if /proc/PID exists (if available)
-	// or try to read process information
-	procDir := "/proc/" + strconv.Itoa(pid)
-	if _, err := os.Stat(procDir); err == nil {
-		return true
-	}
-
-	// Fallback: try to open the process (Windows-specific would need syscalls)
-	// For now, we'll use a simple heuristic
-	return pid > 0 && pid < 65536 // Basic PID range check
+	return checkProcess(pid)
 }
 
 // getCurrentPID returns the current process ID

--- a/internal/lock/process_check_unix.go
+++ b/internal/lock/process_check_unix.go
@@ -1,0 +1,36 @@
+//go:build !windows
+// +build !windows
+
+package lock
+
+import (
+	"errors"
+	"syscall"
+)
+
+// checkProcess checks if a process exists on Unix-like systems
+func checkProcess(pid int) bool {
+	// Try to send signal 0 to the process
+	// If the process exists, we get nil or permission error
+	// If the process doesn't exist, we get ESRCH
+	err := syscall.Kill(pid, 0)
+
+	if err == nil {
+		return true // Process exists and we can signal it
+	}
+
+	// Check the specific error
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		switch errno { //nolint:exhaustive // We only care about specific errno values
+		case syscall.ESRCH:
+			return false // Process doesn't exist
+		case syscall.EPERM:
+			return true // Process exists but we don't have permission
+		default:
+			return false // Other error, assume process doesn't exist
+		}
+	}
+
+	return false
+}

--- a/internal/lock/process_check_windows.go
+++ b/internal/lock/process_check_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+// +build windows
+
+package lock
+
+import (
+	"os"
+	"strconv"
+)
+
+// checkProcess checks if a process exists on Windows
+func checkProcess(pid int) bool {
+	// On Windows, we check if /proc/PID exists (if available)
+	// or try to read process information
+	procDir := "/proc/" + strconv.Itoa(pid)
+	if _, err := os.Stat(procDir); err == nil {
+		return true
+	}
+
+	// Fallback: try to open the process (Windows-specific would need syscalls)
+	// For now, we'll use a simple heuristic
+	return pid > 0 && pid < 65536 // Basic PID range check
+}

--- a/internal/process/signal_unix.go
+++ b/internal/process/signal_unix.go
@@ -1,0 +1,25 @@
+//go:build !windows
+// +build !windows
+
+package process
+
+import (
+	"os"
+	"syscall"
+)
+
+// signalProcess sends a signal to the process
+func signalProcess(proc *os.Process, sig os.Signal) error {
+	return proc.Signal(sig)
+}
+
+// isProcessAlive checks if the process is still alive
+func isProcessAlive(proc *os.Process) bool {
+	err := proc.Signal(syscall.Signal(0))
+	return err == nil
+}
+
+// terminateProcess sends SIGTERM to the process
+func terminateProcess(proc *os.Process) error {
+	return proc.Signal(syscall.SIGTERM)
+}

--- a/internal/process/signal_unix.go
+++ b/internal/process/signal_unix.go
@@ -8,11 +8,6 @@ import (
 	"syscall"
 )
 
-// signalProcess sends a signal to the process
-func signalProcess(proc *os.Process, sig os.Signal) error {
-	return proc.Signal(sig)
-}
-
 // isProcessAlive checks if the process is still alive
 func isProcessAlive(proc *os.Process) bool {
 	err := proc.Signal(syscall.Signal(0))

--- a/internal/process/signal_windows.go
+++ b/internal/process/signal_windows.go
@@ -7,16 +7,6 @@ import (
 	"os"
 )
 
-// signalProcess sends a signal to the process (Windows implementation)
-func signalProcess(proc *os.Process, sig os.Signal) error {
-	// On Windows, we can only kill the process, not send signals
-	if sig == os.Kill {
-		return proc.Kill()
-	}
-	// For other signals, try to kill the process
-	return proc.Kill()
-}
-
 // isProcessAlive checks if the process is still alive (Windows implementation)
 func isProcessAlive(proc *os.Process) bool {
 	// On Windows, we try to get the process state

--- a/internal/process/signal_windows.go
+++ b/internal/process/signal_windows.go
@@ -1,0 +1,36 @@
+//go:build windows
+// +build windows
+
+package process
+
+import (
+	"os"
+)
+
+// signalProcess sends a signal to the process (Windows implementation)
+func signalProcess(proc *os.Process, sig os.Signal) error {
+	// On Windows, we can only kill the process, not send signals
+	if sig == os.Kill {
+		return proc.Kill()
+	}
+	// For other signals, try to kill the process
+	return proc.Kill()
+}
+
+// isProcessAlive checks if the process is still alive (Windows implementation)
+func isProcessAlive(proc *os.Process) bool {
+	// On Windows, we try to get the process state
+	// If Wait returns an error, the process is still running
+	_, err := proc.Wait()
+	if err != nil {
+		// Process is still running
+		return true
+	}
+	return false
+}
+
+// terminateProcess terminates the process (Windows implementation)
+func terminateProcess(proc *os.Process) error {
+	// On Windows, we can only kill the process
+	return proc.Kill()
+}

--- a/internal/process/sysprocattr_unix.go
+++ b/internal/process/sysprocattr_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+// +build !windows
+
+package process
+
+import "syscall"
+
+// setSysProcAttr sets the system process attributes for Unix-like systems
+func setSysProcAttr(attr *syscall.SysProcAttr) *syscall.SysProcAttr {
+	if attr == nil {
+		attr = &syscall.SysProcAttr{}
+	}
+	attr.Setpgid = true
+	return attr
+}

--- a/internal/process/sysprocattr_windows.go
+++ b/internal/process/sysprocattr_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+// +build windows
+
+package process
+
+import "syscall"
+
+// setSysProcAttr sets the system process attributes for Windows
+func setSysProcAttr(attr *syscall.SysProcAttr) *syscall.SysProcAttr {
+	// Windows doesn't support Setpgid
+	// Return the attribute as-is or create a new one
+	if attr == nil {
+		attr = &syscall.SysProcAttr{}
+	}
+	return attr
+}


### PR DESCRIPTION
## Summary
This PR fixes the Windows build failures that prevented the v0.1.0 release from completing successfully.

## Problem
The release workflow failed when building Windows binaries due to Unix-specific system calls and process attributes:
- `syscall.Kill` is not available on Windows
- `SysProcAttr.Setpgid` field doesn't exist on Windows
- Signal handling differs between Unix and Windows platforms

## Solution
Implemented platform-specific code using Go build tags:
- **Process checking**: Separated Unix and Windows implementations 
- **Signal handling**: Created platform-specific functions for process signaling
- **System attributes**: Isolated Unix-specific fields with build tags

## Testing
All platforms now build successfully:
✅ Linux (amd64, arm64)
✅ Darwin/macOS (amd64, arm64)
✅ Windows (amd64, arm64)

## Impact
This fix enables the release workflow to complete and allows users on all platforms to use Portguard.

🤖 Generated with [Claude Code](https://claude.ai/code)