### PR TITLE
release: v0.2.4 version updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4] - 2025-08-11
+
 ### Added
 
 - **Project-Based Command Recognition**: Support for starting processes using project names from configuration
@@ -315,6 +317,7 @@ Automatically detects and manages:
 - `node server.js`, `nodemon`, `vite`
 - And many more development server patterns
 
+[0.2.4]: https://github.com/paveg/portguard/releases/tag/v0.2.4
 [0.2.3]: https://github.com/paveg/portguard/releases/tag/v0.2.3
 [0.2.1]: https://github.com/paveg/portguard/releases/tag/v0.2.1
 [0.2.0]: https://github.com/paveg/portguard/releases/tag/v0.2.0

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # Variables
 BINARY_NAME=portguard
 BUILD_DIR=bin
-VERSION?=0.2.3
+VERSION?=0.2.4
 LDFLAGS=-ldflags "-X github.com/paveg/portguard/internal/cmd.Version=$(VERSION)"
 
 # Default target


### PR DESCRIPTION
## Summary
Update version numbers and CHANGELOG for v0.2.4 release.

This PR contains the version updates that were created locally for the v0.2.4 release:
- Update Makefile VERSION from 0.2.3 to 0.2.4
- Convert CHANGELOG Unreleased section to [0.2.4] - 2025-08-11
- Add v0.2.4 release link to CHANGELOG

## Context
The v0.2.4 release has already been created with tag and GitHub release:
- Tag: v0.2.4 (https://github.com/paveg/portguard/releases/tag/v0.2.4)  
- All features and fixes have been merged in PR #12

This PR ensures the version updates are properly reflected in the main branch.

## Test plan
- [x] Verify CHANGELOG format is correct
- [x] Verify Makefile version is updated to 0.2.4
- [x] Verify build works with new version: `make build && ./bin/portguard --version`

🤖 Generated with [Claude Code](https://claude.ai/code)